### PR TITLE
fix: presignToken in both query params and encoded options

### DIFF
--- a/packages/angular/src/create-document.ts
+++ b/packages/angular/src/create-document.ts
@@ -47,13 +47,13 @@ import { CssVars } from "./css-vars";
 })
 export default class EmbedCreateDocument {
   @Input() host!: EmbedCreateDocumentProps["host"];
+  @Input() presignToken!: EmbedCreateDocumentProps["presignToken"];
   @Input() externalId!: EmbedCreateDocumentProps["externalId"];
   @Input() features!: EmbedCreateDocumentProps["features"];
   @Input() css!: EmbedCreateDocumentProps["css"];
   @Input() cssVars!: EmbedCreateDocumentProps["cssVars"];
   @Input() darkModeDisabled!: EmbedCreateDocumentProps["darkModeDisabled"];
   @Input() additionalProps!: EmbedCreateDocumentProps["additionalProps"];
-  @Input() presignToken!: EmbedCreateDocumentProps["presignToken"];
   @Input() onDocumentCreated!: EmbedCreateDocumentProps["onDocumentCreated"];
   @Input() className!: EmbedCreateDocumentProps["className"];
 
@@ -64,6 +64,7 @@ export default class EmbedCreateDocument {
     const encodedOptions = btoa(
       encodeURIComponent(
         JSON.stringify({
+          token: this.presignToken,
           externalId: this.externalId,
           features: this.features,
           css: this.css,

--- a/packages/angular/src/create-template.ts
+++ b/packages/angular/src/create-template.ts
@@ -47,13 +47,13 @@ import { CssVars } from "./css-vars";
 })
 export default class EmbedCreateTemplate {
   @Input() host!: EmbedCreateTemplateProps["host"];
+  @Input() presignToken!: EmbedCreateTemplateProps["presignToken"];
   @Input() externalId!: EmbedCreateTemplateProps["externalId"];
   @Input() features!: EmbedCreateTemplateProps["features"];
   @Input() css!: EmbedCreateTemplateProps["css"];
   @Input() cssVars!: EmbedCreateTemplateProps["cssVars"];
   @Input() darkModeDisabled!: EmbedCreateTemplateProps["darkModeDisabled"];
   @Input() additionalProps!: EmbedCreateTemplateProps["additionalProps"];
-  @Input() presignToken!: EmbedCreateTemplateProps["presignToken"];
   @Input() onTemplateCreated!: EmbedCreateTemplateProps["onTemplateCreated"];
   @Input() className!: EmbedCreateTemplateProps["className"];
 
@@ -64,6 +64,7 @@ export default class EmbedCreateTemplate {
     const encodedOptions = btoa(
       encodeURIComponent(
         JSON.stringify({
+          token: this.presignToken,
           externalId: this.externalId,
           features: this.features,
           css: this.css,

--- a/packages/angular/src/update-template.ts
+++ b/packages/angular/src/update-template.ts
@@ -47,6 +47,7 @@ import { CssVars } from "./css-vars";
 })
 export default class EmbedUpdateTemplate {
   @Input() host!: EmbedUpdateTemplateProps["host"];
+  @Input() presignToken!: EmbedUpdateTemplateProps["presignToken"];
   @Input() externalId!: EmbedUpdateTemplateProps["externalId"];
   @Input() features!: EmbedUpdateTemplateProps["features"];
   @Input() css!: EmbedUpdateTemplateProps["css"];
@@ -54,7 +55,6 @@ export default class EmbedUpdateTemplate {
   @Input() darkModeDisabled!: EmbedUpdateTemplateProps["darkModeDisabled"];
   @Input() additionalProps!: EmbedUpdateTemplateProps["additionalProps"];
   @Input() templateId!: EmbedUpdateTemplateProps["templateId"];
-  @Input() presignToken!: EmbedUpdateTemplateProps["presignToken"];
   @Input() onTemplateUpdated!: EmbedUpdateTemplateProps["onTemplateUpdated"];
   @Input() className!: EmbedUpdateTemplateProps["className"];
 
@@ -65,6 +65,7 @@ export default class EmbedUpdateTemplate {
     const encodedOptions = btoa(
       encodeURIComponent(
         JSON.stringify({
+          token: this.presignToken,
           externalId: this.externalId,
           features: this.features,
           css: this.css,

--- a/packages/mitosis/src/create-document.lite.tsx
+++ b/packages/mitosis/src/create-document.lite.tsx
@@ -40,6 +40,8 @@ export default function EmbedCreateDocument(props: EmbedCreateDocumentProps) {
       const encodedOptions = btoa(
         encodeURIComponent(
           JSON.stringify({
+            token: props.presignToken,
+
             externalId: props.externalId,
             features: props.features,
 

--- a/packages/mitosis/src/create-template.lite.tsx
+++ b/packages/mitosis/src/create-template.lite.tsx
@@ -40,6 +40,8 @@ export default function EmbedCreateTemplate(props: EmbedCreateTemplateProps) {
       const encodedOptions = btoa(
         encodeURIComponent(
           JSON.stringify({
+            token: props.presignToken,
+
             externalId: props.externalId,
             features: props.features,
 

--- a/packages/mitosis/src/update-template.lite.tsx
+++ b/packages/mitosis/src/update-template.lite.tsx
@@ -41,6 +41,8 @@ export default function EmbedUpdateTemplate(props: EmbedUpdateTemplateProps) {
       const encodedOptions = btoa(
         encodeURIComponent(
           JSON.stringify({
+            token: props.presignToken,
+
             externalId: props.externalId,
             features: props.features,
 

--- a/packages/preact/src/create-document.tsx
+++ b/packages/preact/src/create-document.tsx
@@ -36,6 +36,7 @@ function EmbedCreateDocument(props: EmbedCreateDocumentProps) {
     const encodedOptions = btoa(
       encodeURIComponent(
         JSON.stringify({
+          token: props.presignToken,
           externalId: props.externalId,
           features: props.features,
           css: props.css,

--- a/packages/preact/src/create-template.tsx
+++ b/packages/preact/src/create-template.tsx
@@ -36,6 +36,7 @@ function EmbedCreateTemplate(props: EmbedCreateTemplateProps) {
     const encodedOptions = btoa(
       encodeURIComponent(
         JSON.stringify({
+          token: props.presignToken,
           externalId: props.externalId,
           features: props.features,
           css: props.css,

--- a/packages/preact/src/update-template.tsx
+++ b/packages/preact/src/update-template.tsx
@@ -37,6 +37,7 @@ function EmbedUpdateTemplate(props: EmbedUpdateTemplateProps) {
     const encodedOptions = btoa(
       encodeURIComponent(
         JSON.stringify({
+          token: props.presignToken,
           externalId: props.externalId,
           features: props.features,
           css: props.css,

--- a/packages/react/src/create-document.tsx
+++ b/packages/react/src/create-document.tsx
@@ -36,6 +36,7 @@ function EmbedCreateDocument(props: EmbedCreateDocumentProps) {
     const encodedOptions = btoa(
       encodeURIComponent(
         JSON.stringify({
+          token: props.presignToken,
           externalId: props.externalId,
           features: props.features,
           css: props.css,

--- a/packages/react/src/create-template.tsx
+++ b/packages/react/src/create-template.tsx
@@ -36,6 +36,7 @@ function EmbedCreateTemplate(props: EmbedCreateTemplateProps) {
     const encodedOptions = btoa(
       encodeURIComponent(
         JSON.stringify({
+          token: props.presignToken,
           externalId: props.externalId,
           features: props.features,
           css: props.css,

--- a/packages/react/src/update-template.tsx
+++ b/packages/react/src/update-template.tsx
@@ -37,6 +37,7 @@ function EmbedUpdateTemplate(props: EmbedUpdateTemplateProps) {
     const encodedOptions = btoa(
       encodeURIComponent(
         JSON.stringify({
+          token: props.presignToken,
           externalId: props.externalId,
           features: props.features,
           css: props.css,

--- a/packages/solid/src/create-document.tsx
+++ b/packages/solid/src/create-document.tsx
@@ -34,6 +34,7 @@ function EmbedCreateDocument(props: EmbedCreateDocumentProps) {
     const encodedOptions = btoa(
       encodeURIComponent(
         JSON.stringify({
+          token: props.presignToken,
           externalId: props.externalId,
           features: props.features,
           css: props.css,

--- a/packages/solid/src/create-template.tsx
+++ b/packages/solid/src/create-template.tsx
@@ -34,6 +34,7 @@ function EmbedCreateTemplate(props: EmbedCreateTemplateProps) {
     const encodedOptions = btoa(
       encodeURIComponent(
         JSON.stringify({
+          token: props.presignToken,
           externalId: props.externalId,
           features: props.features,
           css: props.css,

--- a/packages/solid/src/update-template.tsx
+++ b/packages/solid/src/update-template.tsx
@@ -35,6 +35,7 @@ function EmbedUpdateTemplate(props: EmbedUpdateTemplateProps) {
     const encodedOptions = btoa(
       encodeURIComponent(
         JSON.stringify({
+          token: props.presignToken,
           externalId: props.externalId,
           features: props.features,
           css: props.css,

--- a/packages/svelte/src/create-document.svelte
+++ b/packages/svelte/src/create-document.svelte
@@ -32,6 +32,7 @@
   import { CssVars } from "./css-vars";
 
   export let host: EmbedCreateDocumentProps["host"] = undefined;
+  export let presignToken: EmbedCreateDocumentProps["presignToken"];
   export let externalId: EmbedCreateDocumentProps["externalId"] = undefined;
   export let features: EmbedCreateDocumentProps["features"] = undefined;
   export let css: EmbedCreateDocumentProps["css"] = undefined;
@@ -40,7 +41,6 @@
     undefined;
   export let additionalProps: EmbedCreateDocumentProps["additionalProps"] =
     undefined;
-  export let presignToken: EmbedCreateDocumentProps["presignToken"];
   export let onDocumentCreated: EmbedCreateDocumentProps["onDocumentCreated"] =
     undefined;
   export let className: EmbedCreateDocumentProps["className"] = undefined;
@@ -62,6 +62,7 @@
     const encodedOptions = btoa(
       encodeURIComponent(
         JSON.stringify({
+          token: presignToken,
           externalId: externalId,
           features: features,
           css: css,

--- a/packages/svelte/src/create-template.svelte
+++ b/packages/svelte/src/create-template.svelte
@@ -32,6 +32,7 @@
   import { CssVars } from "./css-vars";
 
   export let host: EmbedCreateTemplateProps["host"] = undefined;
+  export let presignToken: EmbedCreateTemplateProps["presignToken"];
   export let externalId: EmbedCreateTemplateProps["externalId"] = undefined;
   export let features: EmbedCreateTemplateProps["features"] = undefined;
   export let css: EmbedCreateTemplateProps["css"] = undefined;
@@ -40,7 +41,6 @@
     undefined;
   export let additionalProps: EmbedCreateTemplateProps["additionalProps"] =
     undefined;
-  export let presignToken: EmbedCreateTemplateProps["presignToken"];
   export let onTemplateCreated: EmbedCreateTemplateProps["onTemplateCreated"] =
     undefined;
   export let className: EmbedCreateTemplateProps["className"] = undefined;
@@ -62,6 +62,7 @@
     const encodedOptions = btoa(
       encodeURIComponent(
         JSON.stringify({
+          token: presignToken,
           externalId: externalId,
           features: features,
           css: css,

--- a/packages/svelte/src/update-template.svelte
+++ b/packages/svelte/src/update-template.svelte
@@ -33,6 +33,7 @@
   import { CssVars } from "./css-vars";
 
   export let host: EmbedUpdateTemplateProps["host"] = undefined;
+  export let presignToken: EmbedUpdateTemplateProps["presignToken"];
   export let externalId: EmbedUpdateTemplateProps["externalId"] = undefined;
   export let features: EmbedUpdateTemplateProps["features"] = undefined;
   export let css: EmbedUpdateTemplateProps["css"] = undefined;
@@ -42,7 +43,6 @@
   export let additionalProps: EmbedUpdateTemplateProps["additionalProps"] =
     undefined;
   export let templateId: EmbedUpdateTemplateProps["templateId"];
-  export let presignToken: EmbedUpdateTemplateProps["presignToken"];
   export let onTemplateUpdated: EmbedUpdateTemplateProps["onTemplateUpdated"] =
     undefined;
   export let className: EmbedUpdateTemplateProps["className"] = undefined;
@@ -64,6 +64,7 @@
     const encodedOptions = btoa(
       encodeURIComponent(
         JSON.stringify({
+          token: presignToken,
           externalId: externalId,
           features: features,
           css: css,

--- a/packages/vue/src/create-document.vue
+++ b/packages/vue/src/create-document.vue
@@ -48,6 +48,7 @@ const src = computed(() => {
   const encodedOptions = btoa(
     encodeURIComponent(
       JSON.stringify({
+        token: props.presignToken,
         externalId: props.externalId,
         features: props.features,
         css: props.css,

--- a/packages/vue/src/create-template.vue
+++ b/packages/vue/src/create-template.vue
@@ -48,6 +48,7 @@ const src = computed(() => {
   const encodedOptions = btoa(
     encodeURIComponent(
       JSON.stringify({
+        token: props.presignToken,
         externalId: props.externalId,
         features: props.features,
         css: props.css,

--- a/packages/vue/src/update-template.vue
+++ b/packages/vue/src/update-template.vue
@@ -49,6 +49,7 @@ const src = computed(() => {
   const encodedOptions = btoa(
     encodeURIComponent(
       JSON.stringify({
+        token: props.presignToken,
         externalId: props.externalId,
         features: props.features,
         css: props.css,


### PR DESCRIPTION
## Description

The issue was that the iframe endpoint expects the token to be included in the hash-encoded options for proper parsing of all the props including `darkModeDisabled` and `cssVar`. Now all components that use presignToken consistently include it in both the query params and the encoded options.