### PR TITLE
fix: add missing files, exports, and entry points to angular package.json

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -2,6 +2,27 @@
   "name": "@documenso/embed-angular",
   "version": "0.5.0",
   "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "types": "dist/index.d.ts",
+  "main": "dist/index.cjs",
+  "module": "dist/fesm2022/documenso-embed-angular.mjs",
+  "exports": {
+    "./package.json": {
+      "default": "./package.json"
+    },
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/fesm2022/documenso-embed-angular.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

- Adds `files`, `main`, `module`, `types`, and `exports` fields to the Angular package's source-level `package.json`, matching every other package in the monorepo.

## Problem

`@documenso/embed-angular@0.5.0` ships raw source instead of compiled output. The root `package.json` was missing:

- **`"files": ["dist"]`** — so `npm publish` included the entire source tree (`src/`, `bin/build.sh`, `angular.json`, tsconfigs, etc.) instead of just `dist/`
- **`"main"`, `"module"`, `"types"`, `"exports"`** — so consumers couldn't resolve imports at all

ng-packagr generates these fields into `dist/package.json`, but `npm publish --workspaces` publishes from the package root, not from `dist/`. Every other package in the monorepo has these fields in its root `package.json`; Angular was the only one missing them.

## Verification

`npm pack --dry-run` now includes only 15 files (all from `dist/` + `package.json`), and all entry points resolve correctly.