### PR TITLE
feat: allow add myself feature

### DIFF
--- a/packages/angular/src/create-envelope.ts
+++ b/packages/angular/src/create-envelope.ts
@@ -8,6 +8,10 @@ export type EmbedCreateEnvelopeProps = {
   host?: string;
   presignToken: string;
   externalId?: string;
+  user?: {
+    name?: string;
+    email?: string;
+  };
   type: "DOCUMENT" | "TEMPLATE";
   folderId?: string;
   css?: string | undefined;
@@ -43,6 +47,7 @@ import type { DeepPartial, EnvelopeEditorSettings } from "./features-type";
 export default class EmbedCreateEnvelope {
   @Input() host!: EmbedCreateEnvelopeProps["host"];
   @Input() externalId!: EmbedCreateEnvelopeProps["externalId"];
+  @Input() user!: EmbedCreateEnvelopeProps["user"];
   @Input() type!: EmbedCreateEnvelopeProps["type"];
   @Input() folderId!: EmbedCreateEnvelopeProps["folderId"];
   @Input() features!: EmbedCreateEnvelopeProps["features"];
@@ -62,6 +67,7 @@ export default class EmbedCreateEnvelope {
       encodeURIComponent(
         JSON.stringify({
           externalId: this.externalId,
+          user: this.user,
           type: this.type,
           folderId: this.folderId,
           features: this.features,

--- a/packages/angular/src/update-envelope.ts
+++ b/packages/angular/src/update-envelope.ts
@@ -8,6 +8,10 @@ export type EmbedUpdateEnvelopeProps = {
   host?: string;
   presignToken: string;
   externalId?: string;
+  user?: {
+    name?: string;
+    email?: string;
+  };
   envelopeId: string;
   css?: string | undefined;
   cssVars?: (CssVars & Record<string, string>) | undefined;
@@ -42,6 +46,7 @@ import type { DeepPartial, EnvelopeEditorSettings } from "./features-type";
 export default class EmbedUpdateEnvelope {
   @Input() host!: EmbedUpdateEnvelopeProps["host"];
   @Input() externalId!: EmbedUpdateEnvelopeProps["externalId"];
+  @Input() user!: EmbedUpdateEnvelopeProps["user"];
   @Input() features!: EmbedUpdateEnvelopeProps["features"];
   @Input() css!: EmbedUpdateEnvelopeProps["css"];
   @Input() cssVars!: EmbedUpdateEnvelopeProps["cssVars"];
@@ -60,6 +65,7 @@ export default class EmbedUpdateEnvelope {
       encodeURIComponent(
         JSON.stringify({
           externalId: this.externalId,
+          user: this.user,
           features: this.features,
           css: this.css,
           cssVars: this.cssVars,

--- a/packages/mitosis/src/create-envelope.lite.tsx
+++ b/packages/mitosis/src/create-envelope.lite.tsx
@@ -8,6 +8,10 @@ export type EmbedCreateEnvelopeProps = {
   host?: string;
   presignToken: string;
   externalId?: string;
+  user?: {
+    name?: string;
+    email?: string;
+  };
 
   type: 'DOCUMENT' | 'TEMPLATE';
   folderId?: string;
@@ -35,6 +39,7 @@ export default function EmbedCreateEnvelope(props: EmbedCreateEnvelopeProps) {
         encodeURIComponent(
           JSON.stringify({
             externalId: props.externalId,
+            user: props.user,
             type: props.type,
             folderId: props.folderId,
             features: props.features,

--- a/packages/mitosis/src/update-envelope.lite.tsx
+++ b/packages/mitosis/src/update-envelope.lite.tsx
@@ -8,6 +8,10 @@ export type EmbedUpdateEnvelopeProps = {
   host?: string;
   presignToken: string;
   externalId?: string;
+  user?: {
+    name?: string;
+    email?: string;
+  };
 
   envelopeId: string;
 
@@ -34,6 +38,7 @@ export default function EmbedUpdateEnvelope(props: EmbedUpdateEnvelopeProps) {
         encodeURIComponent(
           JSON.stringify({
             externalId: props.externalId,
+            user: props.user,
             features: props.features,
             css: props.css,
             cssVars: props.cssVars,

--- a/packages/preact/src/create-envelope.tsx
+++ b/packages/preact/src/create-envelope.tsx
@@ -7,6 +7,10 @@ export type EmbedCreateEnvelopeProps = {
   host?: string;
   presignToken: string;
   externalId?: string;
+  user?: {
+    name?: string;
+    email?: string;
+  };
   type: "DOCUMENT" | "TEMPLATE";
   folderId?: string;
   css?: string | undefined;
@@ -31,6 +35,7 @@ function EmbedCreateEnvelope(props: EmbedCreateEnvelopeProps) {
       encodeURIComponent(
         JSON.stringify({
           externalId: props.externalId,
+          user: props.user,
           type: props.type,
           folderId: props.folderId,
           features: props.features,

--- a/packages/preact/src/update-envelope.tsx
+++ b/packages/preact/src/update-envelope.tsx
@@ -7,6 +7,10 @@ export type EmbedUpdateEnvelopeProps = {
   host?: string;
   presignToken: string;
   externalId?: string;
+  user?: {
+    name?: string;
+    email?: string;
+  };
   envelopeId: string;
   css?: string | undefined;
   cssVars?: (CssVars & Record<string, string>) | undefined;
@@ -30,6 +34,7 @@ function EmbedUpdateEnvelope(props: EmbedUpdateEnvelopeProps) {
       encodeURIComponent(
         JSON.stringify({
           externalId: props.externalId,
+          user: props.user,
           features: props.features,
           css: props.css,
           cssVars: props.cssVars,

--- a/packages/react/src/create-envelope.tsx
+++ b/packages/react/src/create-envelope.tsx
@@ -7,6 +7,10 @@ export type EmbedCreateEnvelopeProps = {
   host?: string;
   presignToken: string;
   externalId?: string;
+  user?: {
+    name?: string;
+    email?: string;
+  };
   type: "DOCUMENT" | "TEMPLATE";
   folderId?: string;
   css?: string | undefined;
@@ -31,6 +35,7 @@ function EmbedCreateEnvelope(props: EmbedCreateEnvelopeProps) {
       encodeURIComponent(
         JSON.stringify({
           externalId: props.externalId,
+          user: props.user,
           type: props.type,
           folderId: props.folderId,
           features: props.features,

--- a/packages/react/src/update-envelope.tsx
+++ b/packages/react/src/update-envelope.tsx
@@ -7,6 +7,10 @@ export type EmbedUpdateEnvelopeProps = {
   host?: string;
   presignToken: string;
   externalId?: string;
+  user?: {
+    name?: string;
+    email?: string;
+  };
   envelopeId: string;
   css?: string | undefined;
   cssVars?: (CssVars & Record<string, string>) | undefined;
@@ -30,6 +34,7 @@ function EmbedUpdateEnvelope(props: EmbedUpdateEnvelopeProps) {
       encodeURIComponent(
         JSON.stringify({
           externalId: props.externalId,
+          user: props.user,
           features: props.features,
           css: props.css,
           cssVars: props.cssVars,

--- a/packages/solid/src/create-envelope.tsx
+++ b/packages/solid/src/create-envelope.tsx
@@ -5,6 +5,10 @@ export type EmbedCreateEnvelopeProps = {
   host?: string;
   presignToken: string;
   externalId?: string;
+  user?: {
+    name?: string;
+    email?: string;
+  };
   type: "DOCUMENT" | "TEMPLATE";
   folderId?: string;
   css?: string | undefined;
@@ -29,6 +33,7 @@ function EmbedCreateEnvelope(props: EmbedCreateEnvelopeProps) {
       encodeURIComponent(
         JSON.stringify({
           externalId: props.externalId,
+          user: props.user,
           type: props.type,
           folderId: props.folderId,
           features: props.features,

--- a/packages/solid/src/update-envelope.tsx
+++ b/packages/solid/src/update-envelope.tsx
@@ -5,6 +5,10 @@ export type EmbedUpdateEnvelopeProps = {
   host?: string;
   presignToken: string;
   externalId?: string;
+  user?: {
+    name?: string;
+    email?: string;
+  };
   envelopeId: string;
   css?: string | undefined;
   cssVars?: (CssVars & Record<string, string>) | undefined;
@@ -28,6 +32,7 @@ function EmbedUpdateEnvelope(props: EmbedUpdateEnvelopeProps) {
       encodeURIComponent(
         JSON.stringify({
           externalId: props.externalId,
+          user: props.user,
           features: props.features,
           css: props.css,
           cssVars: props.cssVars,

--- a/packages/svelte/src/create-envelope.svelte
+++ b/packages/svelte/src/create-envelope.svelte
@@ -4,6 +4,10 @@
     host?: string;
     presignToken: string;
     externalId?: string;
+    user?: {
+      name?: string;
+      email?: string;
+    };
     type: "DOCUMENT" | "TEMPLATE";
     folderId?: string;
     css?: string | undefined;
@@ -27,6 +31,7 @@
 
   export let host: EmbedCreateEnvelopeProps["host"] = undefined;
   export let externalId: EmbedCreateEnvelopeProps["externalId"] = undefined;
+  export let user: EmbedCreateEnvelopeProps["user"] = undefined;
   export let type: EmbedCreateEnvelopeProps["type"];
   export let folderId: EmbedCreateEnvelopeProps["folderId"] = undefined;
   export let features: EmbedCreateEnvelopeProps["features"] = undefined;
@@ -58,6 +63,7 @@
       encodeURIComponent(
         JSON.stringify({
           externalId: externalId,
+          user: user,
           type: type,
           folderId: folderId,
           features: features,

--- a/packages/svelte/src/update-envelope.svelte
+++ b/packages/svelte/src/update-envelope.svelte
@@ -4,6 +4,10 @@
     host?: string;
     presignToken: string;
     externalId?: string;
+    user?: {
+      name?: string;
+      email?: string;
+    };
     envelopeId: string;
     css?: string | undefined;
     cssVars?: (CssVars & Record<string, string>) | undefined;
@@ -26,6 +30,7 @@
 
   export let host: EmbedUpdateEnvelopeProps["host"] = undefined;
   export let externalId: EmbedUpdateEnvelopeProps["externalId"] = undefined;
+  export let user: EmbedUpdateEnvelopeProps["user"] = undefined;
   export let features: EmbedUpdateEnvelopeProps["features"] = undefined;
   export let css: EmbedUpdateEnvelopeProps["css"] = undefined;
   export let cssVars: EmbedUpdateEnvelopeProps["cssVars"] = undefined;
@@ -56,6 +61,7 @@
       encodeURIComponent(
         JSON.stringify({
           externalId: externalId,
+          user: user,
           features: features,
           css: css,
           cssVars: cssVars,

--- a/packages/vue/src/create-envelope.vue
+++ b/packages/vue/src/create-envelope.vue
@@ -13,6 +13,10 @@ export type EmbedCreateEnvelopeProps = {
   host?: string;
   presignToken: string;
   externalId?: string;
+  user?: {
+    name?: string;
+    email?: string;
+  };
   type: "DOCUMENT" | "TEMPLATE";
   folderId?: string;
   css?: string | undefined;
@@ -43,6 +47,7 @@ const src = computed(() => {
     encodeURIComponent(
       JSON.stringify({
         externalId: props.externalId,
+        user: props.user,
         type: props.type,
         folderId: props.folderId,
         features: props.features,

--- a/packages/vue/src/update-envelope.vue
+++ b/packages/vue/src/update-envelope.vue
@@ -13,6 +13,10 @@ export type EmbedUpdateEnvelopeProps = {
   host?: string;
   presignToken: string;
   externalId?: string;
+  user?: {
+    name?: string;
+    email?: string;
+  };
   envelopeId: string;
   css?: string | undefined;
   cssVars?: (CssVars & Record<string, string>) | undefined;
@@ -42,6 +46,7 @@ const src = computed(() => {
     encodeURIComponent(
       JSON.stringify({
         externalId: props.externalId,
+        user: props.user,
         features: props.features,
         css: props.css,
         cssVars: props.cssVars,

--- a/playground/src/components/embeddings/create-envelope.tsx
+++ b/playground/src/components/embeddings/create-envelope.tsx
@@ -37,6 +37,12 @@ const formSchema = z
     apiKey: z.string().optional(),
     presignToken: z.string().optional(),
     externalId: z.string().optional(),
+    user: z
+      .object({
+        name: z.string().optional(),
+        email: z.string().email().optional(),
+      })
+      .optional(),
     type: z.enum(['DOCUMENT', 'TEMPLATE']),
     folderId: z.string().optional(),
     features: EnvelopeFeaturesSchema,
@@ -72,6 +78,10 @@ export default function CreateEnvelopeEmbedding() {
       apiKey: '',
       presignToken: '',
       externalId: '',
+      user: {
+        name: '',
+        email: undefined,
+      },
       folderId: '',
       type: 'DOCUMENT',
       features: DEFAULT_ENVELOPE_FEATURES,
@@ -337,6 +347,42 @@ export default function CreateEnvelopeEmbedding() {
                 )}
               />
 
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="user.email"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>User Email (Optional)</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="email"
+                          placeholder="Enter user email..."
+                          className="font-mono text-sm"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>Email address to prefill for the user</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="user.name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>User Name (Optional)</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Enter user name..." {...field} />
+                      </FormControl>
+                      <FormDescription>Name to prefill for the user</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
               <Separator />
 
               {error && (
@@ -375,6 +421,14 @@ export default function CreateEnvelopeEmbedding() {
                 host={host}
                 presignToken={embedConfig.presignToken}
                 externalId={embedConfig.externalId}
+                user={
+                  embedConfig.user?.email || embedConfig.user?.name
+                    ? {
+                        email: embedConfig.user.email || undefined,
+                        name: embedConfig.user.name || undefined,
+                      }
+                    : undefined
+                }
                 folderId={embedConfig.folderId || undefined}
                 type={embedConfig.type}
                 features={embedConfig.features}

--- a/playground/src/components/embeddings/update-envelope.tsx
+++ b/playground/src/components/embeddings/update-envelope.tsx
@@ -31,6 +31,12 @@ const formSchema = z
     presignToken: z.string().optional(),
     envelopeId: z.string(),
     externalId: z.string().optional(),
+    user: z
+      .object({
+        name: z.string().optional(),
+        email: z.string().email().optional(),
+      })
+      .optional(),
     features: EnvelopeFeaturesSchema,
     darkModeDisabled: z.boolean().optional(),
     language: z.string().optional(),
@@ -65,6 +71,10 @@ export default function UpdateEnvelopeEmbedding() {
       presignToken: '',
       envelopeId: '',
       externalId: '',
+      user: {
+        name: '',
+        email: undefined,
+      },
       features: DEFAULT_ENVELOPE_FEATURES,
       darkModeDisabled: false,
       language: '',
@@ -300,6 +310,43 @@ export default function UpdateEnvelopeEmbedding() {
                 )}
               />
 
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="user.email"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>User Email (Optional)</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="email"
+                          placeholder="Enter user email..."
+                          className="font-mono text-sm"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>Email address to prefill for the user</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="user.name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>User Name (Optional)</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Enter user name..." {...field} />
+                      </FormControl>
+                      <FormDescription>Name to prefill for the user</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
               <Separator />
 
               {error && (
@@ -339,6 +386,14 @@ export default function UpdateEnvelopeEmbedding() {
                 envelopeId={embedConfig.envelopeId}
                 presignToken={embedConfig.presignToken}
                 externalId={embedConfig.externalId}
+                user={
+                  embedConfig.user?.email || embedConfig.user?.name
+                    ? {
+                        email: embedConfig.user.email || undefined,
+                        name: embedConfig.user.name || undefined,
+                      }
+                    : undefined
+                }
                 features={embedConfig.features}
                 darkModeDisabled={embedConfig.darkModeDisabled}
                 language={embedConfig.language || undefined}


### PR DESCRIPTION
Add support for "Add Myself" button in the envelope create and edit flows

Introduces a new optional "user" prop

```
user?: {
    name?: string;
    email?: string;
  };
```